### PR TITLE
Versions and actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -48,6 +48,14 @@ jobs:
         if: env.CONDA_LOCK == 'false'
         name: Check versions
 
+      - run: conda-lock -f environment.yml -p linux-64 --lockfile conda-linux-64.lock
+        if: env.CONDA_LOCK == 'false'
+        name: Generate conda-lock
+
+      - run: cat conda-linux-64.lock
+        if: env.CONDA_LOCK == 'false'
+        name: Check conda-lock
+
       - run: pip install plotly==5.5.0
         if: env.CONDA_LOCK == 'true'
         name: Install plotly

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - python-graphviz
   - ipywidgets>=7.5
   - pandas
-  - matplotlib
+  - matplotlib=3.5.3
   - pillow # section 5.3 etc..
   - pytorch
   - timm


### PR DESCRIPTION
- Fix version of matplotlib as later versions break gtsam 4.2 plotting
- Add creation of a lock file to action so we can make subsequent builds much faster